### PR TITLE
Fix bug in apple touch icon path

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -11,7 +11,7 @@
 {{ partial "inject.stylesheet.html" . }}
 
 <!-- Icons -->
-<link rel="apple-touch-icon-precomposed" sizes="144x144" href="img/apple-touch-icon-144-precomposed.png">
+<link rel="apple-touch-icon-precomposed" sizes="144x144" href="/img/apple-touch-icon-144-precomposed.png">
 <link rel="shortcut icon" href="/img/favicon.png">
 
 <!-- Twitter Card -->


### PR DESCRIPTION
Same correction was already done for the favicon.png path