### PR TITLE
Absolute paths hardcoded in some files

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,9 +17,9 @@ This theme is pretty basic and covers all of the essentials. All you have to do 
 #### Built-in shortcodes
 
 - **`image`** (prop required: **`src`**; props optional: **`alt`**, **`position`** (**left** is default | center | right), **`style`**)
-  - eg: `{{< image src="/img/hello.png" alt="Hello Friend" position="center" style="border-radius: 8px;" >}}`
+  - eg: `{{< image src="{{ $.Site.BaseURL }}/img/hello.png" alt="Hello Friend" position="center" style="border-radius: 8px;" >}}`
 - **`figure`** (same as `image`, plus few optional props: **`caption`**, **`captionPosition`** (left | **center** is default | right), **`captionStyle`**
-  - eg: `{{< figure src="/img/hello.png" alt="Hello Friend" position="center" style="border-radius: 8px;" caption="Hello Friend!" captionPosition="right" captionStyle="color: red;" >}}`
+  - eg: `{{< figure src="{{ $.Site.BaseURL }}/img/hello.png" alt="Hello Friend" position="center" style="border-radius: 8px;" caption="Hello Friend!" captionPosition="right" captionStyle="color: red;" >}}`
 
 #### Code highlighting
 

--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -20,7 +20,7 @@
       {{ end }}
 
       {{ with .Params.Cover }}
-        <img src="/img/{{ . }}" class="post-cover" />
+        <img src="{{ $.Site.BaseURL }}/img/{{ . }}" class="post-cover" />
       {{ end }}
 
       <div class="post-content">

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -17,7 +17,7 @@
     {{ end }}
 
     {{ with .Params.Cover }}
-      <img src="/img/{{ . }}" class="post-cover" />
+      <img src="{{ $.Site.BaseURL }}/img/{{ . }}" class="post-cover" />
     {{ end }}
 
     <div class="post-content">

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -6,13 +6,13 @@
 <link rel="canonical" href="{{ .Permalink }}" />
 
 <!-- CSS -->
-<link rel="stylesheet" href="/assets/style.css">
+<link rel="stylesheet" href="{{ $.Site.BaseURL }}/assets/style.css">
 <link href='https://fonts.googleapis.com/css?family=Source+Sans+Pro:400,700|Source+Code+Pro' rel='stylesheet' type='text/css'>
 {{ partial "inject.stylesheet.html" . }}
 
 <!-- Icons -->
-<link rel="apple-touch-icon-precomposed" sizes="144x144" href="/img/apple-touch-icon-144-precomposed.png">
-<link rel="shortcut icon" href="/img/favicon.png">
+<link rel="apple-touch-icon-precomposed" sizes="144x144" href="{{ $.Site.BaseURL }}/img/apple-touch-icon-144-precomposed.png">
+<link rel="shortcut icon" href="{{ $.Site.BaseURL }}/img/favicon.png">
 
 <!-- Twitter Card -->
 <meta name="twitter:card" content="summary" />

--- a/layouts/partials/inject.script.html
+++ b/layouts/partials/inject.script.html
@@ -1,5 +1,5 @@
 
-  <script src="/assets/main.js"></script>
+  <script src="{{ $.Site.BaseURL }}/assets/main.js"></script>
 
-  <script src="/assets/prism.js"></script>
+  <script src="{{ $.Site.BaseURL }}/assets/prism.js"></script>
 

--- a/layouts/partials/inject.stylesheet.html
+++ b/layouts/partials/inject.stylesheet.html
@@ -1,3 +1,3 @@
 
-  <link rel="stylesheet" href="/assets/style.css">
+  <link rel="stylesheet" href="{{ $.Site.BaseURL }}/assets/style.css">
 

--- a/source/html/inject.script.ejs
+++ b/source/html/inject.script.ejs
@@ -1,3 +1,3 @@
 <% htmlWebpackPlugin.files.js.filter(function(js){ return !/\.css$/.test(js) }).forEach(function(js){ %>
-  <script src="/assets/<%= js %>"></script>
+  <script src="{{ $.Site.BaseURL }}/assets/<%= js %>"></script>
 <% }) %>

--- a/source/html/inject.stylesheet.ejs
+++ b/source/html/inject.stylesheet.ejs
@@ -1,3 +1,3 @@
 <% htmlWebpackPlugin.files.css.forEach(function(css){ %>
-  <link rel="stylesheet" href="/assets/<%= css %>">
+  <link rel="stylesheet" href="{{ $.Site.BaseURL }}/assets/<%= css %>">
 <% }) %>


### PR DESCRIPTION
I'm setting up hugo for the first time and wanted to go with a dark theme. This looks pretty readable and minimalistic, so thanks for the great job. 

I've found that the theme breaks quite badly if `baseUrl` contains a subdirectory, such as `baseUrl = "https://example.com/subdir/"`. I'm not too sure about this webapck and yarn stuff, but prepending absolute URLs in a few offending html files with `{{ $.Site.BaseURL }}` fixes it in all my tests.