### PR TITLE
pluralize posts in list template

### DIFF
--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -1,6 +1,6 @@
 {{ define "main" }}
   <div class="posts">
-    {{ $paginator := .Paginate (where .Data.Pages "Type" "post") }}
+    {{ $paginator := .Paginate (where .Data.Pages "Type" "posts") }}
     {{ range $paginator.Pages }}
     <div class="post on-list">
       <h1 class="post-title"><a href="{{ .Permalink }}">{{ .Title | markdownify }}</a></h1>


### PR DESCRIPTION
This change was required for me to list my posts on a brand new install of Hugo on macOS.

Version:
Hugo Static Site Generator v0.53/extended darwin/amd64 BuildDate: unknown

I'm not sure if it's just because I missed something else but I thought I'd just push this up and saw what you thought.

Thanks for the awesome theme!