### PR TITLE
 Make "Older/Newer posts" texts configurable and allow empty config file

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,8 @@ paginate = 5
     writtenBy = "Written by"
     readMore = "Read more"
     readOtherPosts = "Read other posts"
+    newerPosts = "Newer posts"
+    olderPosts = "Older posts"
 
     [languages.en.params.logo]
       logoText = "hello friend"

--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -20,6 +20,8 @@ paginate = 5
     writtenBy = "Written by"
     readMore = "Read more"
     readOtherPosts = "Read other posts"
+    newerPosts = "Newer posts"
+    olderPosts = "Older posts"
 
     [languages.en.params.logo]
       logoText = "hello friend"

--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -11,7 +11,7 @@
         <span class="post-date">
           {{ .Date.Format "2006-01-02" }}
         </span>
-        {{ with .Params.Author }}<span class="post-author">— {{ $.Site.Params.WrittenBy }} {{ . }}</span>{{ end }}
+        {{ with .Params.Author }}<span class="post-author">— {{ $.Site.Params.WrittenBy | default "Written by" }} {{ . }}</span>{{ end }}
       </div>
 
       {{ if .Params.tags }}
@@ -35,7 +35,7 @@
           {{ end }}
         {{ end }}
       </div>
-      <div><a class="read-more button" href="{{.RelPermalink}}">{{ $.Site.Params.ReadMore }} →</a></div>
+      <div><a class="read-more button" href="{{.RelPermalink}}">{{ $.Site.Params.ReadMore | default "Read more" }} →</a></div>
     </div>
     {{ end }}
     {{ partial "pagination.html" . }}

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -7,7 +7,7 @@
             {{ .Format "2006-01-02" }}
         </span>
       {{ end }}
-      {{ with .Params.Author }}<span class="post-author">— {{ $.Site.Params.WrittenBy }} {{ . }}</span>{{ end }}
+      {{ with .Params.Author }}<span class="post-author">— {{ $.Site.Params.WrittenBy | default "Written by" }} {{ . }}</span>{{ end }}
     </div>
 
     {{ if .Params.tags }}
@@ -28,7 +28,7 @@
     {{ if or .NextInSection .PrevInSection }}
       <div class="pagination">
         <div class="pagination__title">
-          <span class="pagination__title-h">{{ $.Site.Params.ReadOtherPosts }}</span>
+          <span class="pagination__title-h">{{ $.Site.Params.ReadOtherPosts | default "Read other posts" }}</span>
           <hr />
         </div>
         <div class="pagination__buttons">

--- a/layouts/partials/menu.html
+++ b/layouts/partials/menu.html
@@ -8,7 +8,7 @@
       {{ end }}
       {{ if gt (len $.Site.Menus.main) $.Site.Params.showMenuItems }}
         <ul class="menu__sub-inner">
-          <li class="menu__sub-inner-more-trigger">{{ $.Site.Params.MenuMore }} <span class="menu__sub-inner-more-trigger-icon">></span></li>
+          <li class="menu__sub-inner-more-trigger">{{ $.Site.Params.MenuMore | default "Show more" }} <span class="menu__sub-inner-more-trigger-icon">></span></li>
 
           <ul class="menu__sub-inner-more hidden">
             {{ range last (sub (len $.Site.Menus.main) $.Site.Params.showMenuItems) $.Site.Menus.main }}

--- a/layouts/partials/pagination.html
+++ b/layouts/partials/pagination.html
@@ -4,14 +4,14 @@
       <span class="button previous">
         <a href="{{ .Paginator.Prev.URL }}">
           <span class="button__icon">←</span>
-          <span class="button__text">Newer posts</span>
+          <span class="button__text">{{ $.Site.Params.NewerPosts | default "Newer posts" }}</span>
         </a>
       </span>
     {{ end }}
     {{ if .Paginator.HasNext }}
       <span class="button next">
         <a href="{{ .Paginator.Next.URL }}">
-          <span class="button__text">Older posts</span>
+          <span class="button__text">{{ $.Site.Params.OlderPosts | default "Older posts" }}</span>
           <span class="button__icon">→</span>
         </a>
       </span>


### PR DESCRIPTION
This PR makes the "Older posts" and "Newer posts" buttons translatable and allows to have a basic config without any theme specific changes for translated texts which removes unnecessary bloat from the config