### PR TITLE
Removed `img/` prefix from cover page params

### DIFF
--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -23,7 +23,7 @@
       {{ end }}
 
       {{ with .Params.Cover }}
-        <img src="{{ printf "img/%s" . | absURL }}" class="post-cover" />
+        <img src="{{ . | absURL }}" class="post-cover" />
       {{ end }}
 
       <div class="post-content">

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -19,7 +19,7 @@
     {{ end }}
 
     {{ with .Params.Cover }}
-      <img src="{{ printf "img/%s" . | absURL }}" class="post-cover" />
+      <img src="{{ . | absURL }}" class="post-cover" />
     {{ end }}
 
     <div class="post-content">


### PR DESCRIPTION
closes #33 (Don't prepend `img/` on cover links)

`cover: ` links can be updated with
```sh
find ./content/ -type f -name '*.md' -exec sed -i 's~cover: ~cover: img/~g' {} \;
```
for `yml` syntax