### PR TITLE
Append trailing '/' to avoid 301 redirection

### DIFF
--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -21,7 +21,7 @@
       {{ if .Params.tags }}
         <span class="post-tags">
           {{ range .Params.tags }}
-            #<a href="{{ (urlize (printf "tags/%s" . )) | absURL }}">{{ . }}</a>&nbsp;
+            #<a href="{{ (urlize (printf "tags/%s" . )) | absURL }}/">{{ . }}</a>&nbsp;
           {{ end }}
         </span>
       {{ end }}

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -16,7 +16,7 @@
     {{ if .Params.tags }}
       <span class="post-tags">
         {{ range .Params.tags }}
-          #<a href="{{ (urlize (printf "tags/%s" . )) | absURL }}">{{ . }}</a>&nbsp;
+          #<a href="{{ (urlize (printf "tags/%s" . )) | absURL }}/">{{ . }}</a>&nbsp;
         {{ end }}
       </span>
     {{ end }}


### PR DESCRIPTION
This is to improve the SEO of website by avoid 301 redirect on `tags` link. Let me know what you think @panr :pray:. See here: https://www.gotchseo.com/301-redirects/