### PR TITLE
Initial limited support for i18n (multilanguage)

### DIFF
--- a/i18n/en.yaml
+++ b/i18n/en.yaml
@@ -1,0 +1,29 @@
+# Content
+- id: dateFormat
+  translation: "January 2, 2006"
+- id: shortdateFormat
+  translation: "Jan 2, 2006 15:04:05"
+- id: postedOnDate
+  translation: "Posted on {{ .Count }}"
+- id: lastModified
+  translation: "(Last modified on {{ .Count }})"
+- id: translationsLabel
+  translation: "Translations: "
+- id: translationsSeparator
+  translation: ", "
+- id: readMore
+  translation: "Read More"
+- id: olderPosts
+  translation: "Older Posts"
+- id: newerPosts
+  translation: "Newer Posts"
+- id: previousPost
+  translation: "Previous Post"
+- id: nextPost
+  translation: "Next Post"
+- id: readTime
+  translation: "minutes"
+- id: words
+  translation: "words"
+- id: writtenBy
+  translation: "Written by"

--- a/i18n/id.yaml
+++ b/i18n/id.yaml
@@ -1,8 +1,8 @@
 # Content
 - id: dateFormat
-  translation: "2 Januari 2006"
+  translation: "January 2, 2006"
 - id: shortdateFormat
-  translation: "2 Januari 2006 15:04:05"
+  translation: "Jan 2, 2006 15:04:05"
 - id: postedOnDate
   translation: "Diposting pada {{ .Count }}"
 - id: lastModified

--- a/i18n/id.yaml
+++ b/i18n/id.yaml
@@ -1,0 +1,29 @@
+# Content
+- id: dateFormat
+  translation: "2 Januari 2006"
+- id: shortdateFormat
+  translation: "2 Januari 2006 15:04:05"
+- id: postedOnDate
+  translation: "Diposting pada {{ .Count }}"
+- id: lastModified
+  translation: "(Dimodifikasi pada {{ .Count }})"
+- id: translationsLabel
+  translation: "Terjemahan: "
+- id: translationsSeparator
+  translation: ", "
+- id: readMore
+  translation: "Selanjutnya"
+- id: olderPosts
+  translation: "Postingan lama"
+- id: newerPosts
+  translation: "Postingan terbaru"
+- id: previousPost
+  translation: "Postingan sebelumnya"
+- id: nextPost
+  translation: "Postingan selanjutnya"
+- id: readTime
+  translation: "menit"
+- id: words
+  translation: "kata"
+- id: writtenBy
+  translation: "Ditulis oleh"

--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -9,12 +9,19 @@
       <h1 class="post-title"><a href="{{ .Permalink }}">{{ .Title | markdownify }}</a></h1>
       <div class="post-meta">
         <span class="post-date">
-          {{ .Date.Format ($.Site.Params.DateFormatList | default "2006-01-02") }}
+          {{ .Date.Format ($.Site.Params.DateFormatList | default (i18n "dateFormat")) }}
         </span>
-        {{ with .Params.Author }}<span class="post-author">— {{ $.Site.Params.WrittenBy | default "Written by" }} {{ . }}</span>{{ end }}
+        {{ with .Params.Author | default .Site.Author.name }}<span class="post-author">&nbsp;&bull;&nbsp; {{ i18n "writtenBy" }} {{ . }}</span>{{ end }}
         {{ if $.Site.Params.ShowReadingTime }}
-          <span class="post-read-time">— {{ .ReadingTime }} {{ $.Site.Params.MinuteReadingTime | default "min read" }}</span>
+          <span class="post-read-time">&nbsp;&bull;&nbsp; {{ .ReadingTime }} {{ $.Site.Params.MinuteReadingTime | default "min read" }}</span>
         {{ end }}
+        {{ if .IsTranslated -}}
+          {{- $sortedTranslations := sort .Translations "Site.Language.Weight" -}}
+          {{- $links := apply $sortedTranslations "partial" "translation_link.html" "." -}}
+          {{- $cleanLinks := apply $links "chomp" "." -}}
+          {{- $linksOutput := delimit $cleanLinks (i18n "translationsSeparator") -}}
+          &nbsp;&bull;&nbsp;{{ i18n "translationsLabel" }}[ {{ $linksOutput }} ]
+        {{- end }}
       </div>
 
 

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -4,13 +4,20 @@
     <div class="post-meta">
       {{ with .Date | default nil }}
         <span class="post-date">
-            {{ .Format ($.Site.Params.DateFormatSingle | default "2006-01-02") }}
+            {{ .Format ($.Site.Params.DateFormatSingle | default (i18n "dateFormat")) }}
         </span>
       {{ end }}
-      {{ with .Params.Author }}<span class="post-author">— {{ $.Site.Params.WrittenBy | default "Written by" }} {{ . }}</span>{{ end }}
+      {{ with .Params.Author | default .Site.Author.name }}<span class="post-author">&nbsp;&bull;&nbsp; {{ i18n "writtenBy" }} {{ . }}</span>{{ end }}
       {{ if $.Site.Params.ShowReadingTime }}
-        <span class="post-read-time">— {{ .ReadingTime }} {{ $.Site.Params.MinuteReadingTime | default "min read" }}</span>
+        <span class="post-read-time">&nbsp;&bull;&nbsp; {{ .ReadingTime }} {{ $.Site.Params.MinuteReadingTime | default "min read" }}</span>
       {{ end }}
+      {{ if .IsTranslated -}}
+        {{- $sortedTranslations := sort .Translations "Site.Language.Weight" -}}
+        {{- $links := apply $sortedTranslations "partial" "translation_link.html" "." -}}
+        {{- $cleanLinks := apply $links "chomp" "." -}}
+        {{- $linksOutput := delimit $cleanLinks (i18n "translationsSeparator") -}}
+        &nbsp;&bull;&nbsp;{{ i18n "translationsLabel" }}[ {{ $linksOutput }} ]
+      {{- end }}
     </div>
 
     {{ if .Params.tags }}

--- a/layouts/partials/translation_link.html
+++ b/layouts/partials/translation_link.html
@@ -1,0 +1,2 @@
+<a href="{{ .Permalink }}" lang="{{ .Lang }}">{{ default .Lang .Site.Language.LanguageName }}</a>
+


### PR DESCRIPTION
Currently only **English** and **Indonesian** language are added. 
The scope of i18n also only at the translation link on the post (see screenshot below)
- English post part:
![Screen Shot 2019-04-08 at 17 32 16](https://user-images.githubusercontent.com/352737/55717804-556c6380-5a24-11e9-89d0-24477e80191d.png)

- Indonesian post part:
![Screen Shot 2019-04-08 at 17 34 21](https://user-images.githubusercontent.com/352737/55717893-906e9700-5a24-11e9-96fa-822c1ad1721b.png)


Note: this commit is mostly inspired from another theme: Beautifulhugo.