### PR TITLE
Removed urlize from cover links

### DIFF
--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -30,7 +30,7 @@
         {{ if .Params.UseRelativeCover }}
           <img src="{{ (printf "%s%s" .Permalink .Params.Cover ) }}" class="post-cover" />
         {{ else }}
-          <img src="{{ (urlize .Params.Cover | absURL) }}" class="post-cover" />
+          <img src="{{ .Params.Cover | absURL }}" class="post-cover" />
         {{ end }}
       {{ end }}
 

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -25,7 +25,7 @@
       {{ if .Params.UseRelativeCover }}
         <img src="{{ (printf "%s%s" .Permalink .Params.Cover ) }}" class="post-cover" />
       {{ else }}
-        <img src="{{ (urlize .Params.Cover | absURL) }}" class="post-cover" />
+        <img src="{{ .Params.Cover | absURL }}" class="post-cover" />
       {{ end }}
     {{ end }}
 


### PR DESCRIPTION
closes #57 (Bug: Using urlize in cover image URL's replaces uppercase characters with lowercase ones)