### PR TITLE
Update RSS link in head

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -38,7 +38,7 @@
 
 <!-- RSS | JSON -->
 {{ range .AlternativeOutputFormats -}}
-    {{ printf `<link rel="%s" type="%s" href="%s" title="%s" />` .Rel .MediaType.Type .Permalink $.Site.Title | safeHTML }}
+    {{ printf `<link rel="%s" type="%s" href="%s" title="%s" />` .Rel .MediaType.Type .RelPermalink $.Site.Title | safeHTML }}
 {{ end -}}
 
 <!-- head custom -->

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -36,15 +36,10 @@
 {{ range .Params.categories }}<meta property="article:section" content="{{ . }}" />{{ end }}
 {{ if isset .Params "date" }}<meta property="article:published_time" content="{{ time .Date }}" />{{ end }}
 
-<!-- RSS -->
-{{ if .RSSLink }}
-<link href="{{ .Site.RSSLink }}" rel="alternate" type="application/rss+xml" title="{{ .Site.Title }}" />
-{{ end }}
-
-<!-- JSON Feed -->
-{{ if .OutputFormats.Get "json" }}
-<link href="{{ if .OutputFormats.Get "json" }}{{ "feed.json" | absURL }}{{ end }}" rel="alternate" type="application/json" title="{{ .Site.Title }}" />
-{{ end }}
+<!-- RSS | JSON -->
+{{ range .AlternativeOutputFormats -}}
+    {{ printf `<link rel="%s" type="%s" href="%s" title="%s" />` .Rel .MediaType.Type .Permalink $.Site.Title | safeHTML }}
+{{ end -}}
 
 <!-- head custom -->
 {{- partial "extended_head.html" . }}


### PR DESCRIPTION
Hugo `0.55.5` complains that the current rss logic is deprecated.

```
WARN 2019/05/12 21:22:25 Page's .RSSLink is deprecated and will be removed in a future release. Use the Output Format's link, e.g. something like:
    {{ with .OutputFormats.Get "RSS" }}{{ .RelPermalink }}{{ end }}.
```

This PR is based on the current docs and should cover both RSS and JSON (and more alternative output formats): https://gohugo.io/templates/rss/#reference-your-rss-feed-in-head