### PR TITLE
Added a prepended_head.html partial hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,7 +137,8 @@ Adding a cover image to your post is simple and there are two options when you e
 
 - **Archive** — Theme has built-in `archive` page for main content (see `contentTypeName` variable in config). If you need archive on your blog just copy https://github.com/panr/hugo-theme-hello-friend/blob/master/exampleSite/content/archive.md to your `content` dir. If you need multilangual archives, duplicate `content/archive.md` and add `.Lang` variable, eg: `content/archive.pl.md` (remember to change `url` in duplicated file).
 - **Comments** — for adding comments to your blog posts please take a look at `layouts/partials/comments.html` https://github.com/panr/hugo-theme-terminal/blob/master/layouts/partials/comments.html.
-- **Extended `<head>`** — if you need to add something inside `<head>` element, please take a look at `layouts/partial/extended_head.html` https://github.com/panr/hugo-theme-hello-friend/blob/master/layouts/partials/extended_head.html
+- **Prepended `<head>`** — if you need to add something inside `<head>` element, and before any of the theme's `<script>` and `<link>` tags are declared, please take a look at `layouts/partial/prepended_head.html` https://github.com/panr/hugo-theme-hello-friend/blob/master/layouts/partials/prepended_head.html
+- **Extended `<head>`** — if you need to add something inside `<head>` element, after all of all of the theme's `<script>` and `<link>` tags are declared, please take a look at `layouts/partial/extended_head.html` https://github.com/panr/hugo-theme-hello-friend/blob/master/layouts/partials/extended_head.html
 - **Extended `<footer>`** — if you need to add something before end of `<body>` element, please take a look at `layouts/partial/extended_footer.html` https://github.com/panr/hugo-theme-hello-friend/blob/master/layouts/partials/extended_footer.html
 
 ## How to run your site

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -5,6 +5,9 @@
 <meta name="robots" content="noodp"/>
 <link rel="canonical" href="{{ .Permalink }}" />
 
+<!-- head custom -->
+{{- partial "prepended_head.html" . }}
+
 <!-- Theme CSS -->
 <link rel="stylesheet" href="{{ "assets/style.css" | absURL }}">
 

--- a/layouts/partials/prepended_head.html
+++ b/layouts/partials/prepended_head.html
@@ -1,0 +1,4 @@
+<!--
+If you want to include any custom html at the beginning of </head> before scripts or links are declared,
+put it in /layouts/partials/prepended_head.html. Do not put anything in this file - it's only here so that hugo won't throw an error if /layouts/partials/prepended_head.html doesn't exist.
+-->


### PR DESCRIPTION
The purpose for this additional partial hook is to allow custom link, script, or style tags to be inserted before the theme declares any of it's own. This is necessary in a scenario such as linking in a library like `tachyons.css` which sets some default low-specificity tag styles, which are intended to be overwritten by the default styles declared by the template, but since the specificity of both are equally low the template css must be declared afterwards in order to have the higher specificity.