### PR TITLE
Add terms index

### DIFF
--- a/layouts/_default/terms.html
+++ b/layouts/_default/terms.html
@@ -1,0 +1,18 @@
+{{ define "main" }}
+
+<div class="archive">
+    <h1>{{ .Title }}</h1>
+    <ul>
+        {{ $type := .Type }}
+        {{ range $key, $value := .Data.Terms.Alphabetical }}
+        {{ $name := .Name }}
+        {{ $count := .Count }}
+        {{ with $.Site.GetPage (printf "/%s/%s" $type $name) }}
+        <h3 class="archive__post-title">
+            <a href="{{ .Permalink }}">{{ .Name }} ({{ $count }})</a>
+        </h3>
+        {{ end }}
+        {{ end }}
+    </ul>
+</div>
+{{ end }}


### PR DESCRIPTION
I took the term index from #84, changed from taxonomy slug to name in the list, and added it to `layouts/_default`. This provides terms index for taxonomies, without changing how terms pages (`/tags/tag` and `/categories/category`) are shown.

I really felt this theme needed a `/tags` page :) This is how it looks: https://uctrl.dev/tags/