### PR TITLE
Bug Fix to prevent incorrect default Date display in List layout

### DIFF
--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -13,9 +13,11 @@
     <div class="post on-list">
       <h1 class="post-title"><a href="{{ .Permalink }}">{{ .Title | markdownify }}</a></h1>
       <div class="post-meta">
-        <span class="post-date">
-          {{ .Date.Format ($.Site.Params.DateFormatList | default "2006-01-02") }}
-        </span>
+        {{ if .Date }}
+          <span class="post-date">
+            {{ .Date.Format ($.Site.Params.DateFormatList | default "2006-01-02") }}
+          </span>
+        {{ end }}
         {{ with .Params.Author }}<span class="post-author">— {{ $.Site.Params.WrittenBy | default "Written by" }} {{ . }}</span>{{ end }}
         {{ if $.Site.Params.ShowReadingTime }}
           <span class="post-read-time">— {{ .ReadingTime }} {{ $.Site.Params.MinuteReadingTime | default "min read" }}</span>


### PR DESCRIPTION
I think I found a small bug while playing around with date display in the layout files.

Potential Issue: If there is no `.Date` data in a post file, the date is not displayed in the 'single' layout format. However, it is still displayed in the 'list' layout format as the default date 'Jan 01, 0001'.

Am I correct in assuming this is a mistake?

Fix: I've encapsulated the post date display in a quick conditional check to see if there is `.Date` data in a post file. This way it will not display the default date (or any date) in the 'list' layout, which would be consistent with the 'single' layout.

It's a quick fix. I didn't notice any issues from it. Hope it helps! :)