### PR TITLE
PR - Add condition to show *comments* only in defined contentType pages

### DIFF
--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -61,8 +61,12 @@
       {{ end }}
     {{ end }}
     
-    {{ if or (eq .Type $.Site.Params.contentTypeName) (.Params.Comments) }}
-      {{ partial "comments.html" . }}
+
+    {{ if not (eq .Params.Comments "false") }}
+      {{ if or (eq .Type $.Site.Params.contentTypeName) (.Params.Comments) }}
+        {{ partial "comments.html" . }}
+      {{ end }}
     {{ end }}
+    
     </div>
 {{ end }}

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -60,7 +60,9 @@
         </div>
       {{ end }}
     {{ end }}
-
-    {{ partial "comments.html" . }}
+    
+    {{ if eq .Type $.Site.Params.contentTypeName }}
+      {{ partial "comments.html" . }}
+    {{ end }}
     </div>
 {{ end }}

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -61,7 +61,7 @@
       {{ end }}
     {{ end }}
     
-    {{ if eq .Type $.Site.Params.contentTypeName }}
+    {{ if or (eq .Type $.Site.Params.contentTypeName) (.Params.Comments) }}
       {{ partial "comments.html" . }}
     {{ end }}
     </div>


### PR DESCRIPTION
Same as 95906d6 where you disabled pagination for non-posts, but for comments this time.

Generally speaking, I wouldn't think that you'd want comments to show on a project page or an about page, but it may be nice to add a front matter variable check like comments: "true" in case anyone wants to enable them on a specific page. Let me know what you think.