### PR TITLE
Post title should be an H1 element for semantic and search rankings.

### DIFF
--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -3,7 +3,7 @@
   {{ $contentTypeName := cond $isntDefault (string $.Site.Params.contentTypeName) "posts" }}
 
   <div class="post">
-    <h2 class="post-title"><a href="{{ .Permalink }}">{{ .Title | markdownify }}</a></h2>
+    <h1 class="post-title"><a href="{{ .Permalink }}">{{ .Title | markdownify }}</a></h1>
     <div class="post-meta">
       {{ if .Date | default nil }}
         <span class="post-date">


### PR DESCRIPTION
Don't know why this was an H2 element, but it should be an H1 for a few reasons.  Semantically it makes much more sense.  Also, search engines will be looking for an H1 element in order to understand what the page is about and rankings will depend on it.
