### PR TITLE
RSS Enhancements

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,21 +10,24 @@ This theme is pretty basic and covers all of the essentials. All you have to do 
 
 ---
 
-- [Features](#features)
-- [Built-in shortcodes](#built-in-shortcodes)
-- [Code highlighting](#code-highlighting)
-- [How to start](#how-to-start)
-- [How to configure](#how-to-configure)
-- [How to add a cover image to your posts](#how-to-add-a-cover-image-to-your-posts)
-- [How to display the Last Modified Date in your posts](#how-to-display-the-last-modified-date-in-your-posts)
-- [How to hide "Read more" button](#how-to-hide-read-more-button)
-- [Add-ons](#add-ons)
-- [How to run your site](#how-to-run-your-site)
-- [How to edit the theme](#how-to-edit-the-theme)
-- [How to contribute](#how-to-contribute)
-- [Hello Friend theme user?](#hello-friend-theme-user)
-- [Sponsoring](#sponsoring)
-- [Licence](#licence)
+- [Hello Friend](#hello-friend)
+    - [DEMO - https://hugo-hello-friend.now.sh/](#demo---httpshugo-hello-friendnowsh)
+  - [Features](#features)
+      - [Built-in shortcodes](#built-in-shortcodes)
+      - [Code highlighting](#code-highlighting)
+      - [Improved RSS Feed](#improved-rss-feed)
+  - [How to start](#how-to-start)
+  - [How to configure](#how-to-configure)
+  - [How to add a cover image to your posts](#how-to-add-a-cover-image-to-your-posts)
+  - [How to display the Last Modified Date in your posts](#how-to-display-the-last-modified-date-in-your-posts)
+  - [How to hide "Read more" button](#how-to-hide-%22read-more%22-button)
+  - [Add-ons](#add-ons)
+  - [How to run your site](#how-to-run-your-site)
+  - [How to edit the theme](#how-to-edit-the-theme)
+  - [How to contribute](#how-to-contribute)
+  - [`Hello Friend` theme user?](#hello-friend-theme-user)
+  - [Sponsoring](#sponsoring)
+  - [License](#license)
 
 ## Features
 
@@ -52,6 +55,14 @@ By default the theme is using PrismJS to color your code syntax. All you need to
 </pre>
 
 **Supported languages**: bash/shell, css, clike, javascript, apacheconf, actionscript, applescript, c, csharp, cpp, coffeescript, ruby, csp, css-extras, diff, django, docker, elixir, elm, markup-templating, erlang, fsharp, flow, git, go, graphql, less, handlebars, haskell, http, java, json, kotlin, latex, markdown, makefile, objectivec, ocaml, perl, php, php-extras, r, sql, processing, scss, python, jsx, typescript, toml, reason, textile, rust, sass, stylus, scheme, pug, swift, yaml, haml, twig, tsx, vim, visual-basic, wasm.
+
+#### Improved RSS Feed
+
+Some small enhancements have been made to Hugo's [internal RSS](https://github.com/gohugoio/hugo/blob/25a6b33693992e8c6d9c35bc1e781ce3e2bca4be/tpl/tplimpl/embedded/templates/_default/rss.xml) generation code.
+
+**A page's cover image now appears at the top of it's feed display**. This image is set manually using [the cover params](#how-to-add-a-cover-image-to-your-posts). If unset, the RSS generator searches for the first image file in the page bundle whose name includes 'featured', 'cover', or 'thumbnail'.
+
+**You can optionally display the full page content in your RSS feed** (default is Description or Summary data from Front Matter). Set `rssFullText = true` in your `config.toml` file to enable this option.
 
 ## How to start
 
@@ -91,6 +102,10 @@ paginate = 5
 
   # Show reading time in minutes for posts
   showReadingTime = false
+
+  # Show full page content in RSS feed items
+  #(default is Description or Summary metadata in the front matter)
+  # rssFullText = true
 
 [languages]
   [languages.en]

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ By default the theme is using PrismJS to color your code syntax. All you need to
 
 Some small enhancements have been made to Hugo's [internal RSS](https://github.com/gohugoio/hugo/blob/25a6b33693992e8c6d9c35bc1e781ce3e2bca4be/tpl/tplimpl/embedded/templates/_default/rss.xml) generation code.
 
-**A page's cover image now appears at the top of it's feed display**. This image is set manually using [the cover params](#how-to-add-a-cover-image-to-your-posts). If unset, the RSS generator searches for the first image file in the page bundle whose name includes 'featured', 'cover', or 'thumbnail'.
+**A page's cover image now appears at the top of its feed display**. This image is set manually using [the cover params](#how-to-add-a-cover-image-to-your-posts). If unset, the RSS generator searches for the first image file in the page bundle whose name includes 'featured', 'cover', or 'thumbnail'.
 
 **You can optionally display the full page content in your RSS feed** (default is Description or Summary data from Front Matter). Set `rssFullText = true` in your `config.toml` file to enable this option.
 

--- a/README.md
+++ b/README.md
@@ -10,24 +10,22 @@ This theme is pretty basic and covers all of the essentials. All you have to do 
 
 ---
 
-- [Hello Friend](#hello-friend)
-    - [DEMO - https://hugo-hello-friend.now.sh/](#demo---httpshugo-hello-friendnowsh)
-  - [Features](#features)
-      - [Built-in shortcodes](#built-in-shortcodes)
-      - [Code highlighting](#code-highlighting)
-      - [Improved RSS Feed](#improved-rss-feed)
-  - [How to start](#how-to-start)
-  - [How to configure](#how-to-configure)
-  - [How to add a cover image to your posts](#how-to-add-a-cover-image-to-your-posts)
-  - [How to display the Last Modified Date in your posts](#how-to-display-the-last-modified-date-in-your-posts)
-  - [How to hide "Read more" button](#how-to-hide-%22read-more%22-button)
-  - [Add-ons](#add-ons)
-  - [How to run your site](#how-to-run-your-site)
-  - [How to edit the theme](#how-to-edit-the-theme)
-  - [How to contribute](#how-to-contribute)
-  - [`Hello Friend` theme user?](#hello-friend-theme-user)
-  - [Sponsoring](#sponsoring)
-  - [License](#license)
+- [Features](#features)
+    - [Built-in shortcodes](#built-in-shortcodes)
+    - [Code highlighting](#code-highlighting)
+    - [Improved RSS Feed](#improved-rss-feed)
+- [How to start](#how-to-start)
+- [How to configure](#how-to-configure)
+- [How to add a cover image to your posts](#how-to-add-a-cover-image-to-your-posts)
+- [How to display the Last Modified Date in your posts](#how-to-display-the-last-modified-date-in-your-posts)
+- [How to hide "Read more" button](#how-to-hide-read-more-button)
+- [Add-ons](#add-ons)
+- [How to run your site](#how-to-run-your-site)
+- [How to edit the theme](#how-to-edit-the-theme)
+- [How to contribute](#how-to-contribute)
+- [`Hello Friend` theme user?](#hello-friend-theme-user)
+- [Sponsoring](#sponsoring)
+- [License](#license)
 
 ## Features
 
@@ -58,11 +56,13 @@ By default the theme is using PrismJS to color your code syntax. All you need to
 
 #### Improved RSS Feed
 
-Some small enhancements have been made to Hugo's [internal RSS](https://github.com/gohugoio/hugo/blob/25a6b33693992e8c6d9c35bc1e781ce3e2bca4be/tpl/tplimpl/embedded/templates/_default/rss.xml) generation code.
+Some enhancements have been made to Hugo's [internal RSS](https://github.com/gohugoio/hugo/blob/25a6b33693992e8c6d9c35bc1e781ce3e2bca4be/tpl/tplimpl/embedded/templates/_default/rss.xml) generation code.
 
 **A page's cover image now appears at the top of its feed display**. This image is set manually using [the cover params](#how-to-add-a-cover-image-to-your-posts). If unset, the RSS generator searches for the first image file in the page bundle whose name includes 'featured', 'cover', or 'thumbnail'.
 
 **You can optionally display the full page content in your RSS feed** (default is Description or Summary data from Front Matter). Set `rssFullText = true` in your `config.toml` file to enable this option.
+
+**You can choose a site image to be displayed when searching for your RSS feed.** Set `rssImage = "image/url/here"` in your `config.toml` file to enable this option.
 
 ## How to start
 

--- a/layouts/_default/rss.xml
+++ b/layouts/_default/rss.xml
@@ -1,0 +1,36 @@
+{{- $pctx := . -}}
+{{- if .IsHome -}}{{ $pctx = .Site }}{{- end -}}
+{{- $pages := $pctx.RegularPages -}}
+{{- $limit := .Site.Config.Services.RSS.Limit -}}
+{{- if ge $limit 1 -}}
+  {{- $pages = $pages | first $limit -}}
+{{- end -}}
+{{- printf "<?xml version=\"1.0\" encoding=\"utf-8\" standalone=\"yes\"?>" | safeHTML }}
+<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
+  <channel>
+    <title>{{ if eq  .Title  .Site.Title }}{{ .Site.Title }}{{ else }}{{ with .Title }}{{.}} on {{ end }}{{ .Site.Title }}{{ end }}</title>
+    <link>{{ .Permalink }}</link>
+    <description>Recent content {{ if ne  .Title  .Site.Title }}{{ with .Title }}in {{.}} {{ end }}{{ end }}on {{ .Site.Title }}</description>
+    <generator>Hugo -- gohugo.io</generator>{{ with .Site.LanguageCode }}
+    <language>{{.}}</language>{{end}}{{ with .Site.Author.email }}
+    <managingEditor>{{.}}{{ with $.Site.Author.name }} ({{.}}){{end}}</managingEditor>{{end}}{{ with .Site.Author.email }}
+    <webMaster>{{.}}{{ with $.Site.Author.name }} ({{.}}){{end}}</webMaster>{{end}}{{ with .Site.Copyright }}
+    <copyright>{{.}}</copyright>{{end}}{{ if not .Date.IsZero }}
+    <lastBuildDate>{{ .Date.Format "Mon, 02 Jan 2006 15:04:05 -0700" | safeHTML }}</lastBuildDate>{{ end }}
+    {{ with .OutputFormats.Get "RSS" }}
+	{{ printf "<atom:link href=%q rel=\"self\" type=%q />" .Permalink .MediaType | safeHTML }}
+    {{ end }}
+    {{ range $pages }}
+    <item>
+      <title>{{ .Title }}</title>
+      <link>{{ .Permalink }}</link>
+      <pubDate>{{ .Date.Format "Mon, 02 Jan 2006 15:04:05 -0700" | safeHTML }}</pubDate>
+      {{ with .Site.Author.email }}<author>{{.}}{{ with $.Site.Author.name }} ({{.}}){{end}}</author>{{end}}
+      <guid>{{ .Permalink }}</guid>
+      <description>
+      {{ .Summary | html }}
+      </description>
+    </item>
+    {{ end }}
+  </channel>
+</rss>

--- a/layouts/_default/rss.xml
+++ b/layouts/_default/rss.xml
@@ -42,13 +42,13 @@
       <guid>{{ .Permalink }}</guid>
       <description>
         {{ if .Params.Cover }}
-          {{ if .Params.UseRelativeCover }}{{ printf "%s%s%s%s" "<img src=\"" .Permalink .Params.Cover "\"/>"}}
-          {{ else }}{{ printf "%s%s%s" "<img src=\"" (.Params.Cover | absURL) "\"/>"}}
+          {{ if .Params.UseRelativeCover }}{{ printf "<img src=\"%s%s\"/>" .Permalink .Params.Cover }}
+          {{ else }}{{ printf "<img src=\"%s\"/>" (.Params.Cover | absURL) }}
           {{ end }}
         {{ else }}
           {{ $images := .Resources.ByType "image" }}
           {{ $featured := $images.GetMatch "{*featured*,*cover*,*thumbnail*}" }}
-          {{ with $featured }}{{ printf "%s%s%s" "<img src=\"" $featured.Permalink "\"/>"}}{{ end }}
+          {{ with $featured }}{{ printf "<img src=\"%s\"/>" $featured.Permalink }}{{ end }}
         {{ end }}
         
         {{ if .Site.Params.RssFullText }}{{ .Content | html }}

--- a/layouts/_default/rss.xml
+++ b/layouts/_default/rss.xml
@@ -14,6 +14,14 @@
 <rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
   <channel>
     <title>{{ if eq  .Title  .Site.Title }}{{ .Site.Title }}{{ else }}{{ with .Title }}{{.}} on {{ end }}{{ .Site.Title }}{{ end }}</title>
+    
+    {{ if .Site.Params.RssImage }}<image>
+      <url>{{ printf "%s%s" .Permalink .Site.Params.RssImage }}</url>
+      <title>{{ if eq  .Title  .Site.Title }}{{ .Site.Title }}{{ else }}{{ with .Title }}{{.}} on {{ end }}{{ .Site.Title }}{{ end }}</title>
+      <link>{{ .Permalink }}</link>
+    </image>
+    {{ end }}
+    
     <link>{{ .Permalink }}</link>
     <description>Recent content {{ if ne  .Title  .Site.Title }}{{ with .Title }}in {{.}} {{ end }}{{ end }}on {{ .Site.Title }}</description>
     <generator>Hugo -- gohugo.io</generator>{{ with .Site.LanguageCode }}

--- a/layouts/_default/rss.xml
+++ b/layouts/_default/rss.xml
@@ -37,8 +37,14 @@
           {{ $featured := $images.GetMatch "{*featured*,*cover*,*thumbnail*}" }}
           {{ with $featured }}{{ printf "%s%s%s" "<image src=\"" $featured.Permalink "\"/>"}}{{ end }}
         {{ end }}
-      {{ .Summary | html }}
-      </description>
+        
+        {{ if .Site.Params.RssFullText }}{{ .Content | html }}
+        {{ else }}
+          {{ with .Description }}{{ . | html }}
+          {{ else }}{{ .Summary | html }}
+          {{ end }}
+        {{ end }}
+        </description>
     </item>
     {{ end }}
   </channel>

--- a/layouts/_default/rss.xml
+++ b/layouts/_default/rss.xml
@@ -34,13 +34,13 @@
       <guid>{{ .Permalink }}</guid>
       <description>
         {{ if .Params.Cover }}
-          {{ if .Params.UseRelativeCover }}{{ printf "%s%s%s%s" "<image src=\"" .Permalink .Params.Cover "\"/>"}}
-          {{ else }}{{ printf "%s%s%s" "<image src=\"" (.Params.Cover | absURL) "\"/>"}}
+          {{ if .Params.UseRelativeCover }}{{ printf "%s%s%s%s" "<img src=\"" .Permalink .Params.Cover "\"/>"}}
+          {{ else }}{{ printf "%s%s%s" "<img src=\"" (.Params.Cover | absURL) "\"/>"}}
           {{ end }}
         {{ else }}
           {{ $images := .Resources.ByType "image" }}
           {{ $featured := $images.GetMatch "{*featured*,*cover*,*thumbnail*}" }}
-          {{ with $featured }}{{ printf "%s%s%s" "<image src=\"" $featured.Permalink "\"/>"}}{{ end }}
+          {{ with $featured }}{{ printf "%s%s%s" "<img src=\"" $featured.Permalink "\"/>"}}{{ end }}
         {{ end }}
         
         {{ if .Site.Params.RssFullText }}{{ .Content | html }}

--- a/layouts/_default/rss.xml
+++ b/layouts/_default/rss.xml
@@ -28,6 +28,15 @@
       {{ with .Site.Author.email }}<author>{{.}}{{ with $.Site.Author.name }} ({{.}}){{end}}</author>{{end}}
       <guid>{{ .Permalink }}</guid>
       <description>
+        {{ if .Params.Cover }}
+          {{ if .Params.UseRelativeCover }}{{ printf "%s%s%s%s" "<image src=\"" .Permalink .Params.Cover "\"/>"}}
+          {{ else }}{{ printf "%s%s%s" "<image src=\"" (.Params.Cover | absURL) "\"/>"}}
+          {{ end }}
+        {{ else }}
+          {{ $images := .Resources.ByType "image" }}
+          {{ $featured := $images.GetMatch "{*featured*,*cover*,*thumbnail*}" }}
+          {{ with $featured }}{{ printf "%s%s%s" "<image src=\"" $featured.Permalink "\"/>"}}{{ end }}
+        {{ end }}
       {{ .Summary | html }}
       </description>
     </item>

--- a/layouts/_default/rss.xml
+++ b/layouts/_default/rss.xml
@@ -1,9 +1,14 @@
 {{- $pctx := . -}}
 {{- if .IsHome -}}{{ $pctx = .Site }}{{- end -}}
-{{- $pages := $pctx.RegularPages -}}
+{{- $pages := slice -}}
+{{- if or $.IsHome $.IsSection -}}
+{{- $pages = $pctx.RegularPages -}}
+{{- else -}}
+{{- $pages = $pctx.Pages -}}
+{{- end -}}
 {{- $limit := .Site.Config.Services.RSS.Limit -}}
 {{- if ge $limit 1 -}}
-  {{- $pages = $pages | first $limit -}}
+{{- $pages = $pages | first $limit -}}
 {{- end -}}
 {{- printf "<?xml version=\"1.0\" encoding=\"utf-8\" standalone=\"yes\"?>" | safeHTML }}
 <rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">


### PR DESCRIPTION
As discussed in #147, I have added these two options (copied from README update):

**A page's cover image now appears at the top of its feed display**. This image is set manually using the cover params. If unset, the RSS generator searches for the first image file in the page bundle whose name includes 'featured', 'cover', or 'thumbnail'.

**You can optionally display the full page content in your RSS feed** (default is Description or Summary data from Front Matter). Set `rssFullText = true` in your `config.toml` file to enable this option.

**RSS validated and ready to go!**