### PR TITLE
Defer loading of Javascript dependencies

### DIFF
--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -12,6 +12,6 @@
   </div>
 </footer>
 
-<script src="{{ "assets/main.js" | absURL }}"></script>
-<script src="{{ "assets/prism.js" | absURL }}"></script>
+<script defer src="{{ "assets/main.js" | absURL }}"></script>
+<script defer src="{{ "assets/prism.js" | absURL }}"></script>
 {{- partial "extended_footer.html" . }}

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -13,5 +13,15 @@
 </footer>
 
 <script defer src="{{ "assets/main.js" | absURL }}"></script>
-<script defer src="{{ "assets/prism.js" | absURL }}"></script>
+<script>
+  window.addEventListener('DOMContentLoaded', function (e) {
+    var doc = e.target;
+    if (doc.childNodes[1].getElementsByTagName("code").length > 0) {
+      var element = doc.createElement("script");
+      element.src = "{{ "assets/prism.js" | absURL }}";
+      element.async = " ";
+      doc.body.appendChild(element);
+    }
+  });
+</script>
 {{- partial "extended_footer.html" . }}


### PR DESCRIPTION
Checking Lighthouse showed that deferring load of JS dependencies (primarily `prism.js`), has a measurable change in score for ["First Meaningful Paint"](https://scotch.io/courses/10-web-performance-audit-tips-for-your-next-billion-users-in-2018/fmp-first-meaningful-paint) (3.8 sec down to 1.7 sec after 2-3 repeated tests).

Straightforward enough to test this out, and in practice I didn't detect any issues due to this minor optimization (on my personal blog at least).