### PR TITLE
Add possibility to order menu via parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,15 +118,19 @@ paginate = 5
     # path = "/img/your-example-logo.svg"
     # alt = "Your example logo alt text"
 
+    # use weight to order the menu 
+    # or leave it blank to order alphabetically 
     [languages.en.menu]
       [[languages.en.menu.main]]
         identifier = "about"
         name = "About"
         url = "/about"
+        weight = 2
       [[languages.en.menu.main]]
         identifier = "showcase"
         name = "Showcase"
         url = "/showcase"
+        weight = 1
 ```
 
 to `config.toml` file in your Hugo root directory and change params fields. In case you need, here's [a YAML version](https://gist.github.com/panr/8f9b363e358aaa33f6d353c77feee959).

--- a/layouts/partials/menu.html
+++ b/layouts/partials/menu.html
@@ -1,7 +1,7 @@
 <nav class="menu">
   <ul class="menu__inner menu__inner--desktop">
     {{ if or $.Site.Params.showMenuItems (eq $.Site.Params.showMenuItems 0) }}
-      {{ range first $.Site.Params.showMenuItems $.Site.Menus.main }}
+      {{ range first $.Site.Params.showMenuItems $.Site.Menus.main.ByWeight }}
         {{ if not .HasChildren }}
           <li><a href="{{ .URL }}">{{ .Name }}</a></li>
         {{ end }}
@@ -14,7 +14,7 @@
           </li>
 
           <ul class="menu__sub-inner-more hidden">
-            {{ range last (sub (len $.Site.Menus.main) $.Site.Params.showMenuItems) $.Site.Menus.main }}
+            {{ range last (sub (len $.Site.Menus.main.ByWeight) $.Site.Params.showMenuItems) $.Site.Menus.main.ByWeight }}
               {{ if not .HasChildren }}
                 <li><a href="{{ .URL }}">{{ .Name }}</a></li>
               {{ end }}
@@ -23,7 +23,7 @@
         </ul>
       {{ end }}
     {{ else }}
-      {{ range $.Site.Menus.main }}
+      {{ range $.Site.Menus.main.ByWeight }}
         {{ if not .HasChildren }}
           <li><a href="{{ .URL }}">{{ .Name }}</a></li>
         {{ end }}
@@ -32,7 +32,7 @@
   </ul>
 
   <ul class="menu__inner menu__inner--mobile">
-    {{ range $.Site.Menus.main }}
+    {{ range $.Site.Menus.main.ByWeight }}
       {{ if not .HasChildren }}
         <li><a href="{{ .URL }}">{{ .Name }}</a></li>
       {{ end }}


### PR DESCRIPTION
## Problem

Menu can only be sorted alphabetically, but sometimes you may want to display some pages via `showMenuItems` option and you cant really have control over it.

#### Example

I have a `showMenuItems = 2` in config and:

```yaml
[languages.en.menu]
      [[languages.en.menu.main]]
        identifier = "show1"
        name = "Show This"
        url = "/show1"
      [[languages.en.menu.main]]
        identifier = "show2"
        name = "Also show this"
        url = "/show"
      [[languages.en.menu.main]]
        identifier = "hide1"
        name = "Hide"
        url = "/hide"
```

## Solution

Use property **weight** to tweak ordering.

Now I want to show as follows

- Show 2
- Show 1
- More
  - Etc...

```yaml
[languages.en.menu]
      [[languages.en.menu.main]]
        identifier = "show1"
        name = "Show This"
        url = "/show1"
        weight = 2
      [[languages.en.menu.main]]
        identifier = "show2"
        name = "Also show this"
        url = "/show"
        weight = 1
      [[languages.en.menu.main]]
        identifier = "hide1"
        name = "Hide"
        url = "/hide"
        weight = 10
```

**Note:** if one or more menu items have the same **weight** value, it will sort them alphabetically.