### PR TITLE
Make "more" submenu entire li clickable

### DIFF
--- a/source/css/menu.css
+++ b/source/css/menu.css
@@ -128,7 +128,7 @@
 
       li a {
         width: 100%;
-        display:inline-block;
+        display: inline-block;
         padding: 10px;
       }
     }

--- a/source/css/menu.css
+++ b/source/css/menu.css
@@ -112,7 +112,6 @@
       li {
         .menu__inner & {
           margin-left: 0;
-          padding: 10px;
           white-space: nowrap;
 
           &:hover {
@@ -125,6 +124,12 @@
             }
           }
         }
+      }
+
+      li a {
+        width: 100%;
+        display:inline-block;
+        padding: 10px;
       }
     }
   }


### PR DESCRIPTION
Today, only the text inside **more** submenu are clickable.

Change it to make all li clickable.