### PR TITLE
Add a tag in "show more" menu

### DIFF
--- a/layouts/partials/menu.html
+++ b/layouts/partials/menu.html
@@ -9,8 +9,10 @@
       {{ if gt (len $.Site.Menus.main) $.Site.Params.showMenuItems }}
         <ul class="menu__sub-inner">
           <li class="menu__sub-inner-more-trigger">
-            {{ $.Site.Params.MenuMore | default "Show more" }}
-            <span class="menu__sub-inner-more-trigger-icon">{{ partial "greater-icon.html" . }}</span>
+            <a href="#">
+              {{ $.Site.Params.MenuMore | default "Show more" }}
+              <span class="menu__sub-inner-more-trigger-icon">{{ partial "greater-icon.html" . }}</span>
+            </a>
           </li>
 
           <ul class="menu__sub-inner-more hidden">


### PR DESCRIPTION
To make menu styling easy and make the menu more homogeneous, add a `a` tag in "show more" menu link, as it was just a text inside li (breaking a styling in menu)