### PR TITLE
Mathjax support

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -7,6 +7,7 @@
 
 <!-- head custom -->
 {{- partial "prepended_head.html" . }}
+{{ partial "mathjax__support.html" }}
 
 <!-- Theme CSS -->
 <link rel="stylesheet" href="{{ "assets/style.css" | absURL }}">

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -7,7 +7,6 @@
 
 <!-- head custom -->
 {{- partial "prepended_head.html" . }}
-{{ partial "mathjax__support.html" }}
 
 <!-- Theme CSS -->
 <link rel="stylesheet" href="{{ "assets/style.css" | absURL }}">
@@ -18,6 +17,9 @@
 <!-- Icons -->
 <link rel="apple-touch-icon-precomposed" sizes="144x144" href="{{ "img/apple-touch-icon-144-precomposed.png" | absURL }}">
 <link rel="shortcut icon" href="{{ "img/favicon.png" | absURL }}">
+
+<!-- MathJax Support -->
+{{ partial "mathjax_support.html" }}
 
 <!-- Twitter Card -->
 {{ template "_internal/twitter_cards.html" . }}

--- a/layouts/partials/mathjax__support.html
+++ b/layouts/partials/mathjax__support.html
@@ -1,0 +1,28 @@
+<script type="text/javascript" async
+  src="https://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML">
+  MathJax.Hub.Config({
+  tex2jax: {
+    inlineMath: [['$','$'], ['\\(','\\)']],
+    displayMath: [['$$','$$']],
+    processEscapes: true,
+    processEnvironments: true,
+    skipTags: ['script', 'noscript', 'style', 'textarea', 'pre'],
+    TeX: { equationNumbers: { autoNumber: "AMS" },
+         extensions: ["AMSmath.js", "AMSsymbols.js"] }
+  }
+  });
+  MathJax.Hub.Queue(function() {
+    // Fix <code> tags after MathJax finishes running. This is a
+    // hack to overcome a shortcoming of Markdown. Discussion at
+    // https://github.com/mojombo/jekyll/issues/199
+    var all = MathJax.Hub.getAllJax(), i;
+    for(i = 0; i < all.length; i += 1) {
+        all[i].SourceElement().parentNode.className += ' has-jax';
+    }
+  });
+
+  MathJax.Hub.Config({
+  // Autonumbering by mathjax
+  TeX: { equationNumbers: { autoNumber: "AMS" } }
+  });
+</script>

--- a/layouts/partials/mathjax_support.html
+++ b/layouts/partials/mathjax_support.html
@@ -1,5 +1,5 @@
 <script type="text/javascript" async
-  src="https://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML">
+  src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.1/MathJax.js?config=TeX-AMS-MML_HTMLorMML">
   MathJax.Hub.Config({
   tex2jax: {
     inlineMath: [['$','$'], ['\\(','\\)']],


### PR DESCRIPTION
Hi panr, first, thanks for your amazing theme.

I would like to add MathJax support since it's quite useful for my blog, and I'm sure every person that wants to write a little bit of math would like to have this as well.

I used [this post](https://divadnojnarg.github.io/blog/mathjax/) as a reference, using the 2nd option but using the cloudflare CDN since the MathJax CDN redirects to that one.

It works out of the box:
```md
$$
\theta \in [0, 2\pi] \\\\
\phi \in [0, \pi] \\\\
r \in [0, \infty[ \\\\
$$
```
<img width="140" alt="image" src="https://user-images.githubusercontent.com/19335821/83196433-e6f7d280-a109-11ea-8072-e6012056e8da.png">
