### PR TITLE
Added custom alt text functionality to post cover images

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,6 +201,7 @@ Adding a cover image to your post is simple and there are two options when you e
   * Resulting in `https://www.yourpage.com/path/to/absolute/img.jpg`
 * Use `cover = "img.jpg"` and `useRelativeCover = true` to link the image relative to the blog post folder
   * Resulting in `https://www.yourpage.com/posts/blog-entry-xy/img.jpg`
+* Use `coverAlt = "description of image"` to add custom alt text to the cover image (defaults to post or page title as alt text)
 * Use `coverCaption = "Image Credit to [Barry Bluejeans](https://unsplash.com/)"` to add a caption for the cover image.
 
 ## How to display the Last Modified Date in your posts

--- a/layouts/_default/index.html
+++ b/layouts/_default/index.html
@@ -45,9 +45,9 @@
       {{ if .Params.Cover }}
         <figure class="post-cover">
           {{ if .Params.UseRelativeCover }}
-            <img src="{{ (printf "%s%s" .Permalink .Params.Cover ) }}" alt="{{ .Title | plainify | default " " }}"/>
+            <img src="{{ (printf "%s%s" .Permalink .Params.Cover ) }}" alt="{{ .Params.CoverAlt | plainify | default .Title }}"/>
           {{ else }}
-            <img src="{{ .Params.Cover | absURL }}" alt="{{ .Title | plainify | default " " }}"/>
+            <img src="{{ .Params.Cover | absURL }}" alt="{{ .Params.CoverAlt | plainify | default .Title }}"/>
           {{ end }}
 
           {{ if .Params.CoverCaption }}

--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -30,9 +30,9 @@
       {{ if .Params.Cover }}
         <figure class="post-cover">
           {{ if .Params.UseRelativeCover }}
-            <img src="{{ (printf "%s%s" .Permalink .Params.Cover ) }}" alt="{{ .Title | plainify | default " " }}" />
+            <img src="{{ (printf "%s%s" .Permalink .Params.Cover ) }}" alt="{{ .Params.CoverAlt | plainify | default .Title }}" />
           {{ else }}
-            <img src="{{ .Params.Cover | absURL }}" alt="{{ .Title | plainify | default " " }}" />
+            <img src="{{ .Params.Cover | absURL }}" alt="{{ .Params.CoverAlt | plainify | default .Title }}" />
           {{ end }}
 
           {{ if .Params.CoverCaption }}

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -34,9 +34,9 @@
     {{ if .Params.Cover }}
       <figure class="post-cover">
         {{ if .Params.UseRelativeCover }}
-          <img src="{{ (printf "%s%s" .Permalink .Params.Cover ) }}" alt="{{ .Title | plainify | default " " }}" />
+          <img src="{{ (printf "%s%s" .Permalink .Params.Cover ) }}" alt="{{ .Params.CoverAlt | plainify | default .Title }}" />
         {{ else }}
-          <img src="{{ .Params.Cover | absURL }}" alt="{{ .Title | plainify | default " " }}" />
+          <img src="{{ .Params.Cover | absURL }}" alt="{{ .Params.CoverAlt | plainify | default .Title }}" />
         {{ end }}
 
         {{ if .Params.CoverCaption }}


### PR DESCRIPTION
The current image alt text for a cover image defaults to the post title. This is not great a11y. An alt text should be a description of the image itself.

This update adds instruction and functionality to define a custom alt text description for a cover image, which falls back to the default of the post or page title.