### PR TITLE
Fix .Summary

### DIFF
--- a/layouts/_default/index.html
+++ b/layouts/_default/index.html
@@ -65,7 +65,7 @@
           {{ . | markdownify }}
         {{ else }}
           {{ if .Truncated }}
-            {{ .Summary | markdownify }}
+            {{ .Summary }}
           {{ end }}
         {{ end }}
       </div>

--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -53,7 +53,7 @@
             {{ . | markdownify }}
             {{ else }}
             {{ if .Truncated }}
-              {{ .Summary | markdownify }}
+              {{ .Summary }}
             {{ end }}
           {{ end }}
         </div>


### PR DESCRIPTION
Fixes the display of .Summary by removing `markdownify` from it.
This should resolve #203 (and #127, #100).