### PR TITLE
FIX - add alignment info to imgproc and figure shortcodes

### DIFF
--- a/layouts/shortcodes/figure.html
+++ b/layouts/shortcodes/figure.html
@@ -1,6 +1,7 @@
 {{ if .Get "src" }}
   <figure class="{{ with .Get "position"}}{{ . }}{{ else -}} left {{- end }}" >
-    <img src="{{ .Get "src" | safeURL }}" {{ with .Get "alt" }} alt="{{ . | plainify }}" {{ end }} {{ with .Get "style" }} style="{{ . | safeCSS }}" {{ end }} />
+    <img src="{{ .Get "src" | safeURL }}" {{ with .Get "alt" }} alt="{{ . | plainify }}" {{ end }} {{ with .Get "style" }} style="{{ . | safeCSS }}" {{ end }}
+      class="{{ with .Get "position"}}{{ . }}{{ else -}} left {{- end }}" />
     {{ if .Get "caption" }}
       <figcaption class="{{ with .Get "captionPosition"}}{{ . }}{{ else -}} center {{- end }}" {{ with .Get "captionStyle" }} style="{{ . | safeCSS }}" {{ end }}>{{ .Get "caption" | markdownify }}</figcaption>
     {{ end }}

--- a/layouts/shortcodes/imgproc.html
+++ b/layouts/shortcodes/imgproc.html
@@ -21,9 +21,10 @@
     src="{{ $image.RelPermalink }}"
     width="{{ $image.Width }}"
     height="{{ $image.Height }}"
+    class="{{ with $position }}{{ . }}{{ else -}} left {{- end }}"
   />
-  {{ with .Inner }}
-    <figcaption>
+	{{ with .Inner }}
+    <figcaption class="{{ with $position }}{{ . }}{{ else -}} left {{- end }}">
       {{ . }}
     </figcaption>
   {{ end }}


### PR DESCRIPTION
The imgproc and figure shortcodes have some alignment issues. The `<img>` element is always left-aligned within the figure element and can look strange when the caption is wider than the image. (Maybe related to recent figure styling updates?)

![Screen Shot 2020-09-13 at 16 17 02](https://user-images.githubusercontent.com/1312251/93028874-92a33080-f5dc-11ea-9ea1-0ea932610844.png)

My current fix is to add the class position parameters to the internal img tags. The alignment of the image will match the alignment of the figure. I'm wondering if it's a little hacky, but it does work.

![Screen Shot 2020-09-13 at 16 18 59](https://user-images.githubusercontent.com/1312251/93028924-d7c76280-f5dc-11ea-9f9a-7c9ca4213e14.png)

If this works for you, it should be ready to go.