### PR TITLE
Move post cover to partial

### DIFF
--- a/layouts/_default/index.html
+++ b/layouts/_default/index.html
@@ -47,17 +47,7 @@
       {{ end }}
 
       {{ if .Params.Cover }}
-        <figure class="post-cover">
-          {{ if .Params.UseRelativeCover }}
-            <img src="{{ (printf "%s%s" .Permalink .Params.Cover ) }}" alt="{{ .Params.CoverAlt | plainify | default .Title }}"/>
-          {{ else }}
-            <img src="{{ .Params.Cover | absURL }}" alt="{{ .Params.CoverAlt | plainify | default .Title }}"/>
-          {{ end }}
-
-          {{ if .Params.CoverCaption }}
-            <figcaption class="center">{{ .Params.CoverCaption | markdownify }}</figcaption>
-          {{ end }}
-        </figure>
+        {{ partial "postcover.html" . }}
       {{ end }}
 
       <div class="post-content">

--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -35,17 +35,7 @@
         {{ end }}
 
         {{ if .Params.Cover }}
-          <figure class="post-cover">
-         {{ if .Params.UseRelativeCover }}
-            <img src="{{ (printf "%s%s" .Permalink .Params.Cover ) }}" alt="{{ .Params.CoverAlt | plainify | default .Title }}" />
-          {{ else }}
-            <img src="{{ .Params.Cover | absURL }}" alt="{{ .Params.CoverAlt | plainify | default .Title }}" />
-            {{ end }}
-
-            {{ if .Params.CoverCaption }}
-              <figcaption class="center">{{ .Params.CoverCaption | markdownify }}</figcaption>
-            {{ end }}
-          </figure>
+          {{ partial "postcover.html" . }}
         {{ end }}
 
         <div class="post-content">

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -39,17 +39,7 @@
     {{ end }}
 
     {{ if .Params.Cover }}
-      <figure class="post-cover">
-        {{ if .Params.UseRelativeCover }}
-          <img src="{{ (printf "%s%s" .Permalink .Params.Cover ) }}" alt="{{ .Params.CoverAlt | plainify | default .Title }}" />
-        {{ else }}
-          <img src="{{ .Params.Cover | absURL }}" alt="{{ .Params.CoverAlt | plainify | default .Title }}" />
-        {{ end }}
-
-        {{ if .Params.CoverCaption }}
-          <figcaption class="center">{{ .Params.CoverCaption | markdownify }}</figcaption>
-        {{ end }}
-      </figure>
+      {{ partial "postcover.html" . }}
     {{ end }}
 
     <div class="post-content">

--- a/layouts/partials/postcover.html
+++ b/layouts/partials/postcover.html
@@ -1,0 +1,11 @@
+<figure class="post-cover">
+  {{ if .Params.UseRelativeCover }}
+    <img src="{{ (printf "%s%s" .Permalink .Params.Cover ) }}" alt="{{ .Params.CoverAlt | plainify | default .Title }}"/>
+  {{ else }}
+    <img src="{{ .Params.Cover | absURL }}" alt="{{ .Params.CoverAlt | plainify | default .Title }}"/>
+  {{ end }}
+
+  {{ if .Params.CoverCaption }}
+    <figcaption class="center">{{ .Params.CoverCaption | markdownify }}</figcaption>
+  {{ end }}
+</figure>


### PR DESCRIPTION
The post cover code is duplicated on `index`, `list` and `single`. Instead use a partial.

This will make it easier for users to make their own post cover implementation, like i have :)

This change should not affect existing installations.