### PR TITLE
add the ability to disable table of contents per-page/post

### DIFF
--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -54,8 +54,10 @@
 
     <div class="post-content">
       {{ if or .Params.Toc $.Site.Params.Toc }}
+        {{ if ne .Params.Toc false }}
         <h2>Table of Contents</h2>
         <aside class="table-of-contents">{{ .TableOfContents }}</aside>
+        {{ end }}
       {{ end }}
       {{ .Content }}
     </div>


### PR DESCRIPTION
As things stand, having a global toc=true and front matter toc=false result in Table of contents being visible, which is unexpected. This patch fixes that.

