### PR TITLE
Fix tags links in multilingual

### DIFF
--- a/layouts/_default/index.html
+++ b/layouts/_default/index.html
@@ -41,7 +41,7 @@
       {{ if .Params.tags }}
         <span class="post-tags">
           {{ range .Params.tags }}
-            <a href="{{ (urlize (printf "tags/%s" . )) | absURL }}/">#{{ . }}</a>&nbsp;
+            <a href="{{ (urlize (printf "tags/%s" . )) | absLangURL }}/">#{{ . }}</a>&nbsp;
           {{ end }}
         </span>
       {{ end }}

--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -29,7 +29,7 @@
         {{ if .Params.tags }}
           <span class="post-tags">
             {{ range .Params.tags }}
-              <a href="{{ (urlize (printf "tags/%s" . )) | absURL }}/">#{{ . }}</a>&nbsp;
+              <a href="{{ (urlize (printf "tags/%s" . )) | absLangURL }}/">#{{ . }}</a>&nbsp;
             {{ end }}
           </span>
         {{ end }}

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -33,7 +33,7 @@
     {{ if .Params.tags }}
       <span class="post-tags">
         {{ range .Params.tags }}
-          <a href="{{ (urlize (printf "tags/%s" . )) | absURL }}/">#{{ . }}</a>&nbsp;
+          <a href="{{ (urlize (printf "tags/%s" . )) | absLangURL }}/">#{{ . }}</a>&nbsp;
         {{ end }}
       </span>
     {{ end }}


### PR DESCRIPTION
When using multiple languages the tags links on the blogposts header use always the main language base URL (even when you're on a post on other language). This PR fixes that