### PR TITLE
Feature: capability to set OS preferred theme

### DIFF
--- a/assets/js/theme.js
+++ b/assets/js/theme.js
@@ -1,18 +1,53 @@
-// Toggle theme
+/**
+ * Responsive Dark Mode theme.
+ *
+ * Capable of following OS preference.
+ *
+ */
 
-const getTheme = window.localStorage && window.localStorage.getItem("theme");
+// Theme Toggle element
 const themeToggle = document.querySelector(".theme-toggle");
-const isDark = getTheme === "dark";
 
-if (getTheme !== null) {
-  document.body.classList.toggle("dark-theme", isDark);
+// User preference toggle event listener
+// Code block is unchanged since be313316fd08989ccd6a1ac17ce69a62196cd58
+themeToggle.addEventListener("click", () => {
+    document.body.classList.toggle("dark-theme");
+    window.localStorage &&
+        window.localStorage.setItem(
+            "theme",
+            document.body.classList.contains("dark-theme") ? "dark" : "light",
+        );
+});
+
+// Handle theme switch for the initial function
+function doToggle(color) {
+    switch (color) {
+        case "dark":
+            document.body.classList.toggle("dark-theme");
+            break;
+        case "light":
+            document.body.classList.remove("dark-theme");
+            break;
+    }
 }
 
-themeToggle.addEventListener("click", () => {
-  document.body.classList.toggle("dark-theme");
-  window.localStorage &&
-    window.localStorage.setItem(
-      "theme",
-      document.body.classList.contains("dark-theme") ? "dark" : "light",
-    );
-});
+// Detect the color scheme the operating system prefers
+function detectOSColorTheme() {
+    if (window.matchMedia("(prefers-color-scheme: dark)").matches) {
+        return "dark";
+    } else {
+        return "light";
+    }
+}
+
+// Set the initial theme based on the order of preference
+// Order:
+// 1. User preferred theme setting picked with themeToggle (if present).
+// 2. OS preferred setting.
+(() => {
+    const chosenTheme = window.localStorage && window.localStorage.getItem("theme");
+    const osTheme = detectOSColorTheme();
+    const currentTheme = chosenTheme || osTheme
+    localStorage.setItem("theme", currentTheme);
+    doToggle(currentTheme);
+})();


### PR DESCRIPTION
Hi @panr, i have noticed that OS-based preferred color scheme is not supported yet. So i implemented a trivial solution that does exactly this.

It follows current flow:

1. If a visitor clicked the theme toggle before then the user choice is respected.
2. If it's a new visitor if will comply with `prefers-color-scheme` feature and set the theme accordingly. 

Tested with FF 91, Chrome 92.0.45,  Safari 14.1.2 and iOS 14.7.1 Safari. Works as expected.