### PR TITLE
remove $ from scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,13 +99,13 @@ You can download the theme manually by going to [https://github.com/panr/hugo-th
 You can also clone it directly to your Hugo folder:
 
 ```bash
-$ git clone https://github.com/panr/hugo-theme-hello-friend.git themes/hello-friend
+git clone https://github.com/panr/hugo-theme-hello-friend.git themes/hello-friend
 ```
 
 If you don't want to make any radical changes, it's the best option, because you can get new updates when they are available. To do so, include it as a git submodule:
 
 ```bash
-$ git submodule add https://github.com/panr/hugo-theme-hello-friend.git themes/hello-friend
+git submodule add https://github.com/panr/hugo-theme-hello-friend.git themes/hello-friend
 ```
 
 ⚠️ **The theme needs at least Hugo version 0.74.x**.


### PR DESCRIPTION
The $ before the git command has to be removed in order for the git command to work properly.