### PR TITLE
Adding support for a Dockerized build process

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,1 @@
+node_modules

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,31 @@
+# A simple and lightweight Docker container for building the Hello Friend Hugo Theme
+#
+# To use:
+# First, build a Docker image:
+#  $ cd $theme_dir
+#  $ docker build . --tag <some_tag_name>
+#
+# Now, to rebuild the theme:
+#  $ cd $theme_dir
+#  $ docker run -it \
+#    --mount type=bind,source="$(pwd)",destination=/hello-friend \
+#    <some_tag_name>:latest
+#
+# The newly built theme files will be written back into your theme's directory
+# through the magic of Docker bind mounts
+
+FROM alpine:latest
+
+# You must rebuild the Docker image if you modify either of these files
+ADD package.json yarn.lock ./
+
+RUN apk add --no-cache npm && \
+    npm install --global husky yarn && \
+    npm install --global && \
+    npx browserslist@latest --update-db && \
+    yarn
+
+WORKDIR /hello-friend
+
+# This is executed each time you `docker run` the container
+ENTRYPOINT [ "npx", "webpack", "--mode=production" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,16 +2,16 @@
 #
 # To use:
 # First, build a Docker image:
-#  $ cd $theme_dir
+#  $ cd themes/hello-friend
 #  $ docker build . --tag <some_tag_name>
 #
 # Now, to rebuild the theme:
-#  $ cd $theme_dir
+#  $ cd themes/hello-friend
 #  $ docker run -it \
 #    --mount type=bind,source="$(pwd)",destination=/hello-friend \
 #    <some_tag_name>:latest
 #
-# The newly built theme files will be written back into your theme's directory
+# The newly built theme files will be written back into the theme directory
 # through the magic of Docker bind mounts
 
 FROM alpine:latest

--- a/README.md
+++ b/README.md
@@ -255,6 +255,23 @@ or rebuild theme
 ```bash
 yarn build
 ```
+### Rebuild the theme using Docker
+If you don't have, or don't want to install `npm`, `yarn` and their dependencies on your system you can easily rebuild this theme using a Docker container. `npm`, `yarn`, and all dependant packages will be installed and configured within a dedicated Docker image, and rebuilding the theme is a single command.
+
+First, build a Docker image:
+```bash
+cd themes/hello-friend
+docker build . --tag <some_tag_name>
+```
+When the Docker build step completes, you now have a Docker image with all software needed to rebuild the theme. You should only need to rebuild the Docker image if you make changes to `package.json` or `yarn.lock`.
+
+To rebuild the theme, start a new Docker container which upon startup will automatically execute `webpack --mode=production`. The theme directory is presented to the Docker container through the `--mount` option.
+```bash
+docker run -it \
+--mount type=bind,source="$(pwd)",destination=/hello-friend \
+<some_tag_name>:latest
+```
+The build step should take a few seconds, and the newly built theme files will be written back into the theme directory.
 
 To see the changes (remember to restart `hugo server`).
 


### PR DESCRIPTION
This PR adds support for rebuilding this theme using a Docker container. A Dockerized build provides the ability to isolate the build environment for this theme in a dedicated Docker container reducing the chance for package version/dependency conflicts, or enabling a build environment where you can't or don't want to install `npm`.

The end result is a compiled theme identical to the output from the instructions provided in the README.