### PR TITLE
Make inline code font size relative to parent

### DIFF
--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -131,7 +131,7 @@ code, kbd {
   padding: 1px 6px;
   margin: 0 2px;
   border-radius: 5px;
-  font-size: .9rem;
+  font-size: .9em;
   font-weight: normal;
   font-feature-settings: normal;
 


### PR DESCRIPTION
Previously, `rem` was used, which sets the font-size irrespective of its surrounding context. Changing this to `em` makes it possible to e.g. use inline code in headings without rendering them much smaller than the surrounding font.

Can be seen in effect on https://mbrgm.de/blog/kotlin-filternotnull-in-typescript/

### Before

<img width="300" alt="Screenshot 2023-01-07-20 36 40" src="https://user-images.githubusercontent.com/2971615/211167653-89ce5587-6e7a-4266-ad75-9c3ede9790f2.png">

### After

<img width="300" alt="Screenshot 2023-01-07-20 37 20" src="https://user-images.githubusercontent.com/2971615/211167662-75209d4c-7f68-4cb8-b632-90f7eb8ec938.png">

