### PR TITLE
update figure shortcode to support link, target, rel attributes

### DIFF
--- a/layouts/shortcodes/figure.html
+++ b/layouts/shortcodes/figure.html
@@ -1,6 +1,10 @@
 {{ if .Get "src" }}
   <figure class="{{ with .Get "position"}}{{ . }}{{ else -}} left {{- end }}" >
+    {{- if .Get "link" -}}
+      <a href="{{ .Get "link" }}"{{ with .Get "target" }} target="{{ . }}"{{ end }}{{ with .Get "rel" }} rel="{{ . }}"{{ end }}>
+    {{- end -}}
     <img src="{{ .Get "src" | safeURL }}" {{ with .Get "alt" }} alt="{{ . | plainify }}" {{ end }} {{ with .Get "style" }} style="{{ . | safeCSS }}" {{ end }} />
+    {{- if .Get "link" }}</a>{{ end -}}
     {{ if .Get "caption" }}
       <figcaption class="{{ with .Get "captionPosition"}}{{ . }}{{ else -}} center {{- end }}" {{ with .Get "captionStyle" }} style="{{ . | safeCSS }}" {{ end }}>{{ .Get "caption" | markdownify }}</figcaption>
     {{ end }}


### PR DESCRIPTION
The default `figure` shortcode in Hugo supports linking images using the `link`, `target`, and `rel` attributes on the image.

e.g.

```
{{< figure src="image.png" link="image.png" target="_blank" >}}
```

This change is just copied right from the default shortcode here: https://github.com/gohugoio/hugo/blob/master/tpl/tplimpl/embedded/templates/shortcodes/figure.html